### PR TITLE
[PR] 좋아요 api 호출 시 redis 에러 발생 원인 수정

### DIFF
--- a/src/main/java/com/st/eighteen_be/config/redis/RedisConfig.java
+++ b/src/main/java/com/st/eighteen_be/config/redis/RedisConfig.java
@@ -12,7 +12,6 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -45,8 +44,7 @@ public class RedisConfig {
         stringRedisTemplate.setKeySerializer(new StringRedisSerializer());
         stringRedisTemplate.setConnectionFactory(redisConnectionFactory());
 
-        GenericToStringSerializer<Object> genericToStringSerializer = new GenericToStringSerializer<>(Object.class);
-        stringRedisTemplate.setValueSerializer(genericToStringSerializer);
+        stringRedisTemplate.setValueSerializer(new StringRedisSerializer());
 
         return stringRedisTemplate;
     }

--- a/src/main/java/com/st/eighteen_be/user/api/FileApiController.java
+++ b/src/main/java/com/st/eighteen_be/user/api/FileApiController.java
@@ -24,10 +24,10 @@ public class FileApiController {
     // TODO: 썸네일용 이미지 조회 및 원본 사진 삭제 시 리사이징 사진도 같이 지워져야함
     @Operation(summary = "preSignedUrl & 접근 key 생성", description = "s3에 이미지 업로드를 위한 url 및 접근 key 생성")
     @PostMapping("/v1/api/file/upload")
-    public ApiResp<List<String[]>> fileUpload(@RequestParam("uniqueId") String unqueId,
+    public ApiResp<List<String[]>> fileUpload(@RequestParam("uniqueId") String uniqueId,
                                               @RequestParam("fileNames") List<String> fileNames) {
 
-        return ApiResp.success(HttpStatus.OK, s3Service.generateUploadPreSignedUrls(fileNames,unqueId));
+        return ApiResp.success(HttpStatus.OK, s3Service.generateUploadPreSignedUrls(fileNames,uniqueId));
     }
 
     @Operation(summary = "접근 key로 미디어 파일 삭제", description = "접근 key로 미디어 파일 삭제")

--- a/src/main/java/com/st/eighteen_be/user/service/LikeService.java
+++ b/src/main/java/com/st/eighteen_be/user/service/LikeService.java
@@ -31,13 +31,11 @@ public class LikeService {
         UserInfo user = userService.findById(userId);
         String likedId = Integer.toString(user.getId());
 
-        if (Boolean.TRUE.equals(likeCountRedisTemplate.opsForSet().isMember(
-                userLikesKey,likedId))
-        ) {
+        if (Boolean.TRUE.equals(userLikesRedisTemplate.opsForSet().isMember(userLikesKey,likedId))) {
             throw new IllegalStateException("Already liked");
         }
 
-        userLikesRedisTemplate.opsForSet().add(userLikesKey, likedId);
+        userLikesRedisTemplate.opsForSet().add(userLikesKey,likedId);
         likeCountRedisTemplate.opsForValue().increment(LIKE_COUNT_PREFIX + likedId);
     }
 
@@ -46,7 +44,7 @@ public class LikeService {
         UserInfo user = userService.findById(userId);
         String likedId = Integer.toString(user.getId());
 
-        if (Boolean.FALSE.equals(likeCountRedisTemplate.opsForSet().isMember(userLikesKey, likedId))) {
+        if (Boolean.FALSE.equals(userLikesRedisTemplate.opsForSet().isMember(userLikesKey, likedId))) {
             //TODO: 레디스에 없지만 DB에는 있는지 확인하는 로직이 필요함
             throw new IllegalStateException("Not liked yet");
         }


### PR DESCRIPTION
- 직렬화 방식 수정

좋아요 api 호출 시 좋아요 수를 redis.opsForValue().increment() 메서드를 통해 value 값을 +1 해주는 로직인데
좋아요 수가 특정 상황에서 json 형태로 직렬화 되면서 큰 따옴표를 포함한 채로 저장이 되었고, 그로 인해 이스케이프 문자가 포함되어 숫자로 인식 못하는 에러가 발생

기존에 사용하던 GenericToStringSerializer<Object>는 모든 객체를 문자열로 변환하기 때문에, 저장된 문자열을 다시 숫자형으로 변환할 때 문제가 발생할 수 있다. 예를 들어, 저장된 문자열이 "123"이라고 하더라도, 만약 이 문자열이 이스케이프 처리되어 \"123\"와 같은 형태로 저장되면, 이를 increment() 할 때 `ERR value is not an integer or out of range` 에러 발생

StringRedisSerializer는 문자열만 처리하므로, 숫자를 문자열로 변환하여 저장하고, 다시 읽을 때도 문자열로 처리하여 일관성을 유지할 수 있기에 GenericToStringSerializer<Object> 에서 StringRedisSerializer로 수정